### PR TITLE
Allow configuration of all htpasswd-files and accounts through hiera.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,33 @@ encrypt 'password' with 'salt' using the apache MD5 method
 ### ht_sha1('password')
 encrypt 'password' using the apache SHA1 method
 
+## Hiera
+
+You can configure all htpasswd files in hiera as well:
+
+    htpasswd::files::htpasswdfiles:
+      '/etc/nginx/htpasswd':
+        ensure: present
+        owner: 'www-data'
+        group: 'root'
+        users:
+          'nancy':
+            cryptpasswd: '$apr1$fhz0Twfs8rET9F9dbwNc7R$NazJdE/.'
+          'zoe':
+            cryptpasswd: '$apr1$naEC$MpXMfbJAGsT4SWa1gTNbj6mTs/'
+          'dan':
+            cryptpasswd: '$apr1$n04/cJWO$Nmpr9rs.tTsTvsuWgLV3k.'
+      '/var/www/restricted/.htpasswd':
+        users:
+          'dan-2':
+            username: 'dan'
+            cryptpasswd: '$apr1$n04/cJWO$Nmpr9rs.tTsTvsuWgLV3k.'
+
+Then simply
+
+    include ::htpasswd::files
+
+to write all configured htpasswd files.
+
 # Credits
 Apache MD5 algorithm ruby implementation taken from https://github.com/copiousfreetime/htauth by Jeremy Hinegardner.

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -1,0 +1,20 @@
+define htpasswd::file (
+  $ensure = present,
+  $mode = '0640',
+  $owner = 'root',
+  $group = 'root',
+  $users = {},
+) {
+  file { $name:
+    ensure => $ensure,
+    mode   => $mode,
+    owner  => $owner,
+    group  => $group,
+  }
+  if $ensure == present {
+    $defaults = {
+      target => $name,
+    }
+    create_resources(htpasswd, $users, $defaults)
+  }
+}

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -1,0 +1,5 @@
+class htpasswd::files (
+  $htpasswdfiles = {},
+) {
+  create_resources(htpasswd::file, $htpasswdfiles)
+}


### PR DESCRIPTION
I was missing a way to configure all htpasswd-files in hiera. Unfortunate the module-name is already taken for the type `htpasswd` so it's not possible to have a class named `htpasswd` and configure the files in `htpasswd::files`. This is why I created a new class `htpasswd::files` and called the parameter `htpasswd::files::htpasswdfiles`.

Let me know what you think! I'd love to see this in your module :).
