### PR TITLE
Fixed [Puppet.newtype is deprecated]

### DIFF
--- a/lib/puppet/type/htgroup.rb
+++ b/lib/puppet/type/htgroup.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:htgroup) do
+  Puppet::Type.newtype(:htgroup) do
     @doc = "Manage an Apache style htgroup file
 
     htgroup { 'admins':

--- a/lib/puppet/type/htpasswd.rb
+++ b/lib/puppet/type/htpasswd.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:htpasswd) do
+  Puppet::Type.newtype(:htpasswd) do
     @doc = "Manage an Apache style htpasswd file
 
     htpasswd { 'user':


### PR DESCRIPTION
Fixed two puppet 4.x deprecation warnings
